### PR TITLE
Update CsvRowDataSerializer.cs to handle multiline values

### DIFF
--- a/FileBaseContext/Serializers/CsvRowDataSerializer.cs
+++ b/FileBaseContext/Serializers/CsvRowDataSerializer.cs
@@ -201,10 +201,11 @@ internal class CsvRowDataSerializer : IRowDataSerializer
                     value = $"\"{value.Replace("\"", "\"\"")}\""; // escape quotes
                 }
 
-                if (value != null && value.Contains(',') && !value.StartsWith('"') && !value.EndsWith('"'))
+                if (value != null && ((value.Contains(',') && !value.StartsWith('"') && !value.EndsWith('"')) || (value.Contains('\n') )))
                 {
                     value = $"\"{value}\"";
                 }
+                
 
                 writer.Write(value);
             }


### PR DESCRIPTION
Basically checks if an value contains an \n cause that should denote a new line, and that should fix problems with multiline strings