### PR TITLE
JsonRowDataSerializer: correction in the Deserialize method

### DIFF
--- a/FileBaseContext/Serializers/JsonRowDataSerializer.cs
+++ b/FileBaseContext/Serializers/JsonRowDataSerializer.cs
@@ -2,7 +2,9 @@
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using System.Diagnostics;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 
 namespace kDg.FileBaseContext.Serializers;
 
@@ -82,6 +84,7 @@ public class JsonRowDataSerializer : IRowDataSerializer
         return new JsonSerializerOptions()
         {
             AllowTrailingCommas = true,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
             WriteIndented = true,
             Converters =
             {

--- a/FileBaseContext/Serializers/JsonRowDataSerializer.cs
+++ b/FileBaseContext/Serializers/JsonRowDataSerializer.cs
@@ -49,9 +49,9 @@ public class JsonRowDataSerializer : IRowDataSerializer
         }
 
         var keyValueFactory = (IPrincipalKeyValueFactory<TKey>)_keyValueFactory;
-        var keyValues = new object[_keyColumns.Length];
         foreach (var rowData in rowsData)
         {
+            var keyValues = new object[_keyColumns.Length];
             var columnValues = rowData.ColumnValues;
 
             for (int i = 0; i < keyValues.Length; i++)


### PR DESCRIPTION
Create a new keyValues object in the foreach loop so that the next run does not change the previous added dictionary keys and a "System.ArgumentException: 'An item with the same key has already been added'" error occurs.