### PR TITLE
Support set json options

### DIFF
--- a/FileBaseContext.Tests/Data/DbTestContext.cs
+++ b/FileBaseContext.Tests/Data/DbTestContext.cs
@@ -1,7 +1,13 @@
 ﻿using System.IO.Abstractions.TestingHelpers;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using FileBaseContext.Tests.Data.Entities;
 using kDg.FileBaseContext.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.IO.Converters;
 
 namespace FileBaseContext.Tests.Data;
 
@@ -29,6 +35,19 @@ public class DbTestContext : DbContext
         optionsBuilder.UseFileBaseContextDatabase(DatabaseName, null, services =>
         {
             services.AddMockFileSystem(_fileSystem);
+            var options = new JsonSerializerOptions()
+            {
+                AllowTrailingCommas = true,
+                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                WriteIndented = true,
+                Converters =
+                {
+                    new GeoJsonConverterFactory()
+                },
+                NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+                ReferenceHandler = ReferenceHandler.Preserve,
+            };
+            services.AddSingleton(options);
         });
     }
 

--- a/FileBaseContext.Tests/Data/DbTestContext.cs
+++ b/FileBaseContext.Tests/Data/DbTestContext.cs
@@ -35,19 +35,12 @@ public class DbTestContext : DbContext
         optionsBuilder.UseFileBaseContextDatabase(DatabaseName, null, services =>
         {
             services.AddMockFileSystem(_fileSystem);
-            var options = new JsonSerializerOptions()
+            services.ConfigureJsonSerializerOptions(jsonOptions =>
             {
-                AllowTrailingCommas = true,
-                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-                WriteIndented = true,
-                Converters =
-                {
-                    new GeoJsonConverterFactory()
-                },
-                NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
-                ReferenceHandler = ReferenceHandler.Preserve,
-            };
-            services.AddSingleton(options);
+                jsonOptions.Converters.Add(new GeoJsonConverterFactory());
+                jsonOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
+                jsonOptions.ReferenceHandler = ReferenceHandler.Preserve;
+            });
         });
     }
 

--- a/FileBaseContext.Tests/Data/DbTestContext.cs
+++ b/FileBaseContext.Tests/Data/DbTestContext.cs
@@ -7,6 +7,7 @@ using FileBaseContext.Tests.Data.Entities;
 using kDg.FileBaseContext.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Converters;
 
 namespace FileBaseContext.Tests.Data;
@@ -29,6 +30,7 @@ public class DbTestContext : DbContext
     public DbSet<Setting> Settings { get; set; }
     public DbSet<SimpleEntity> SimpleEntities { get; set; }
     public DbSet<User> Users { get; set; }
+    public DbSet<Place> Places { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -38,8 +40,6 @@ public class DbTestContext : DbContext
             services.ConfigureJsonSerializerOptions(jsonOptions =>
             {
                 jsonOptions.Converters.Add(new GeoJsonConverterFactory());
-                jsonOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
-                jsonOptions.ReferenceHandler = ReferenceHandler.Preserve;
             });
         });
     }
@@ -111,6 +111,13 @@ public class DbTestContext : DbContext
         };
 
         db.Users.Add(user);
+        
+        if (!db.Places.Any())
+        {
+            db.Places.Add(new Place() { Id = 1, Name = "St. Sophia's Cathedral", Location = new Point(30.5137373, 50.4529874) });
+            db.Places.Add(new Place() { Id = 2, Name = "Kyiv-Pechersk Lavra", Location = new Point(30.5529251, 50.4338034) });
+            db.Places.Add(new Place() { Id = 3, Name = "St. Michael's Golden-Domed Monastery", Location = new Point(30.5177251, 50.4533034) });
+        }
 
         db.SaveChanges();
     }

--- a/FileBaseContext.Tests/Data/Entities/Place.cs
+++ b/FileBaseContext.Tests/Data/Entities/Place.cs
@@ -1,0 +1,10 @@
+using NetTopologySuite.Geometries;
+
+namespace FileBaseContext.Tests.Data.Entities;
+
+public class Place
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public Point Location { get; set; }
+}

--- a/FileBaseContext.Tests/DbContextTestClassBase.cs
+++ b/FileBaseContext.Tests/DbContextTestClassBase.cs
@@ -3,6 +3,12 @@ using kDg.FileBaseContext.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions.TestingHelpers;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
+using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.IO.Converters;
 
 namespace FileBaseContext.Tests
 {
@@ -59,6 +65,19 @@ namespace FileBaseContext.Tests
             options.UseFileBaseContextDatabase(typeof(TContext).Name, null, services =>
             {
                 services.AddMockFileSystem(FileSystem);
+                JsonSerializerOptions jsonSerializerOptions = new ()
+                {
+                    AllowTrailingCommas = true,
+                    Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                    WriteIndented = true,
+                    Converters =
+                    {
+                        new GeoJsonConverterFactory()
+                    },
+                    NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+                    ReferenceHandler = ReferenceHandler.Preserve,
+                };
+                services.AddSingleton(jsonSerializerOptions);
             });
         }
 

--- a/FileBaseContext.Tests/DbContextTestClassBase.cs
+++ b/FileBaseContext.Tests/DbContextTestClassBase.cs
@@ -65,19 +65,11 @@ namespace FileBaseContext.Tests
             options.UseFileBaseContextDatabase(typeof(TContext).Name, null, services =>
             {
                 services.AddMockFileSystem(FileSystem);
-                JsonSerializerOptions jsonSerializerOptions = new ()
+                services.ConfigureJsonSerializerOptions(jsonOptions =>
                 {
-                    AllowTrailingCommas = true,
-                    Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-                    WriteIndented = true,
-                    Converters =
-                    {
-                        new GeoJsonConverterFactory()
-                    },
-                    NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
-                    ReferenceHandler = ReferenceHandler.Preserve,
-                };
-                services.AddSingleton(jsonSerializerOptions);
+                    jsonOptions.AllowTrailingCommas = true;
+                    jsonOptions.Encoder = JavaScriptEncoder.Create(UnicodeRanges.All);
+                });
             });
         }
 

--- a/FileBaseContext.Tests/FileBaseContext.Tests.csproj
+++ b/FileBaseContext.Tests/FileBaseContext.Tests.csproj
@@ -15,6 +15,9 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="NetTopologySuite" Version="2.6.0" />
+		<PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
+		<PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
 		<PackageReference Include="System.IO.Abstractions" Version="20.0.4" />
 		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="20.0.4" />
 	</ItemGroup>

--- a/FileBaseContext.Tests/FileBaseContext.Tests.csproj
+++ b/FileBaseContext.Tests/FileBaseContext.Tests.csproj
@@ -16,7 +16,6 @@
 		<PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0" />
 		<PackageReference Include="NetTopologySuite" Version="2.6.0" />
-		<PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
 		<PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
 		<PackageReference Include="System.IO.Abstractions" Version="20.0.4" />
 		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="20.0.4" />

--- a/FileBaseContext.Tests/Json/JsonSimplePositiveTests.cs
+++ b/FileBaseContext.Tests/Json/JsonSimplePositiveTests.cs
@@ -15,13 +15,14 @@ public class JsonSimplePositiveTests
         using var context = CreateDbContext();
         DbTestContext.InitDb(context);
 
-        Assert.AreEqual(6, FileSystem.AllFiles.Count());
+        Assert.AreEqual(7, FileSystem.AllFiles.Count());
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("Content.json")));
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("ContentEntry.json")));
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("Messurement.json")));
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("Setting.json")));
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("SimpleEntity.json")));
         Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("User.json")));
+        Assert.IsTrue(FileSystem.AllFiles.Any(x => x.Contains("Place.json")));
     }
 
     [TestMethod]
@@ -164,6 +165,18 @@ public class JsonSimplePositiveTests
         Assert.AreEqual(DateTime.Parse("01/01/0001 00:00:00"), user1.UpdatedOn);
         Assert.AreEqual("jane_smith_name", user1.Username);
     }
+    
+    [TestMethod]
+    public void VerifyPlaces()
+    {
+        using var context = CreateDbContext();
+        DbTestContext.InitDb(context);
+
+        Assert.AreEqual("St. Sophia's Cathedral", context.Places.Find(1).Name);
+        Assert.AreEqual(30.5529251, context.Places.Find(2).Location.X);
+        Assert.AreEqual(50.4533034, context.Places.Find(3).Location.Y);
+    }
+
 
     protected override DbTestContext CreateDbContext(DbContextOptions<DbTestContext> options)
     {

--- a/FileBaseContext/Extensions/JsonExtensions.cs
+++ b/FileBaseContext/Extensions/JsonExtensions.cs
@@ -1,0 +1,28 @@
+// // Description :    Definition of JsonExtensions.cs class
+// //
+// // Copyright © 2025 - 2025, Alcon. All rights reserved.
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace kDg.FileBaseContext.Extensions;
+
+public static class JsonExtensions {
+    /// <summary>
+    /// Extension methods for configuring <see cref="JsonSerializerOptions"/> in an <see cref="IServiceCollection"/>.
+    /// It finds the existing <see cref="JsonSerializerOptions"/> instance or creates a new one if it doesn't exist.
+    /// </summary>
+    public static IServiceCollection ConfigureJsonSerializerOptions(this IServiceCollection services,
+        Action<JsonSerializerOptions> configure) {
+        var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(JsonSerializerOptions));
+
+        if (descriptor == null) {
+            services.AddSingleton(new JsonSerializerOptions());
+            descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(JsonSerializerOptions));
+        }
+
+        configure(descriptor!.ImplementationInstance as JsonSerializerOptions);
+
+        return services;
+    }
+}

--- a/FileBaseContext/FileBaseContext.csproj
+++ b/FileBaseContext/FileBaseContext.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>5.0.0</Version>
+		<Version>5.1.0</Version>
 		<Company>k.D.g</Company>
 		<Authors>Kous</Authors>
 		<Description>File based database provider for Entity Framework Core (for development purposes)</Description>
@@ -18,8 +18,8 @@
 		<PackageProjectUrl>https://github.com/dualbios/FileBaseContext</PackageProjectUrl>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<DelaySign>false</DelaySign>
-		<AssemblyVersion>5.0.0.0</AssemblyVersion>
-		<FileVersion>5.0.0.0</FileVersion>
+		<AssemblyVersion>5.1.0.0</AssemblyVersion>
+		<FileVersion>5.1.0.0</FileVersion>
 		<RootNamespace>kDg.FileBaseContext</RootNamespace>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>

--- a/FileBaseContext/Serializers/CsvRowDataSerializerFactory.cs
+++ b/FileBaseContext/Serializers/CsvRowDataSerializerFactory.cs
@@ -5,7 +5,9 @@ namespace kDg.FileBaseContext.Serializers;
 
 internal class CsvRowDataSerializerFactory : IRowDataSerializerFactory
 {
-    public IRowDataSerializer Create<TKey>(IEntityType entityType, IPrincipalKeyValueFactory<TKey> keyValueFactory)
+    public IRowDataSerializer Create<TKey>(IEntityType entityType, 
+                                           IPrincipalKeyValueFactory<TKey> keyValueFactory,
+                                           IServiceProvider serviceProvider)
     {
         return new CsvRowDataSerializer(entityType, keyValueFactory);
     }

--- a/FileBaseContext/Serializers/IRowDataSerializerFactory.cs
+++ b/FileBaseContext/Serializers/IRowDataSerializerFactory.cs
@@ -5,5 +5,7 @@ namespace kDg.FileBaseContext.Serializers;
 
 public interface IRowDataSerializerFactory
 {
-    public IRowDataSerializer Create<TKey>(IEntityType entityType, IPrincipalKeyValueFactory<TKey> keyValueFactory);
+    public IRowDataSerializer Create<TKey>(IEntityType entityType, 
+                                           IPrincipalKeyValueFactory<TKey> keyValueFactory, 
+                                           IServiceProvider serviceProvider);
 }

--- a/FileBaseContext/Serializers/JsonRowDataSerializerFactory.cs
+++ b/FileBaseContext/Serializers/JsonRowDataSerializerFactory.cs
@@ -5,8 +5,10 @@ namespace kDg.FileBaseContext.Serializers;
 
 internal class JsonRowDataSerializerFactory : IRowDataSerializerFactory
 {
-    public IRowDataSerializer Create<TKey>(IEntityType entityType, IPrincipalKeyValueFactory<TKey> keyValueFactory)
+    public IRowDataSerializer Create<TKey>(IEntityType entityType, 
+                                           IPrincipalKeyValueFactory<TKey> keyValueFactory,
+                                           IServiceProvider serviceProvider)
     {
-        return new JsonRowDataSerializer(entityType, keyValueFactory);
+        return new JsonRowDataSerializer(entityType, keyValueFactory, serviceProvider);
     }
 }

--- a/FileBaseContext/Storage/FileBaseContextTable.cs
+++ b/FileBaseContext/Storage/FileBaseContextTable.cs
@@ -31,7 +31,7 @@ public class FileBaseContextTable<TKey> : IFileBaseContextTable
         _options = options;
         _primaryKey = entityType.FindPrimaryKey();
         _keyValueFactory = _primaryKey.GetPrincipalKeyValueFactory<TKey>();
-        _serializer = serviceProvider.GetRequiredService<IRowDataSerializerFactory>().Create(entityType, _keyValueFactory);
+        _serializer = serviceProvider.GetRequiredService<IRowDataSerializerFactory>().Create(entityType, _keyValueFactory, serviceProvider);
 
         _fileManager.Init(_options);
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://www.nuget.org/packages/FileBaseContext/
 | ---------------- | --------------- |
 | 1.0.x  | 7  |
 | 2.0.x thru 4.0.x  | 8  |
-| 5.0.x | 9  |
+| 5.0.x thru 5.1.x  | 9  |
 
 ## Configure Database Context
 
@@ -74,6 +74,22 @@ protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 }
 ```
 Please find an example in the SimplePositiveTests class in the test project
+
+## Update for 5.1.0
+
+You can now specify serialization options in `UseFileBaseContextDatabase`, for example adding a converter like [GeoJSON4STJ](https://www.nuget.org/packages/NetTopologySuite.IO.GeoJSON4STJ).Add commentMore actions
+
+```cs
+options.UseFileBaseContextDatabase(location: "userDb", applyServices: services =>
+{
+    services.ConfigureJsonSerializerOptions(options =>
+    {
+        options.Converters.Add(new GeoJsonConverterFactory());
+    });
+});
+```
+
+This will enable you to use [Spatial Data](https://learn.microsoft.com/en-us/ef/core/modeling/spatial) with the addition of the [NetTopologySuite](https://www.nuget.org/packages/NetTopologySuite) library.
 
 ## Update for 5.0.0
 


### PR DESCRIPTION
Added ability to specify serialisation options in `UseFileBaseContextDatabase`, for example, adding a converter like [GeoJSON4STJ](https://www.nuget.org/packages/NetTopologySuite.IO.GeoJSON4STJ)